### PR TITLE
Update PHP-Bignumbers dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "litipk/php-bignumbers": "0.7.2"
+        "litipk/php-bignumbers": "0.8.4"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0"


### PR DESCRIPTION
Update PHP-Bignumbers dependency to ensure that many critical bugfixes are applied.